### PR TITLE
Update env.yaml ADD gcc and gxx from anaconda to compile colorcorrect

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -1,7 +1,10 @@
 name: p37
 channels:
   - defaults
+  - anaconda
 dependencies:
+  - gcc_linux-64
+  - gxx_linux-64
   - _libgcc_mutex=0.1=main
   - blas=1.0=mkl
   - ca-certificates=2021.7.5=h06a4308_1


### PR DESCRIPTION
This update adds gcc and gxx compilers from anaconda so that the pip install colorcorrect command succeeds. This is an issue caused by anaconda with python 3.7

https://github.com/ContinuumIO/anaconda-issues/issues/11152